### PR TITLE
Compiler error fixes

### DIFF
--- a/Harmony Patches/Patch_XRL_Core_XRLCore.cs
+++ b/Harmony Patches/Patch_XRL_Core_XRLCore.cs
@@ -44,7 +44,8 @@ namespace QudUX.HarmonyPatches
         }
     }
 
-    [HarmonyPatch(typeof(XRL.Core.XRLCore))]
+    //[HarmonyPatch(typeof(XRL.Core.XRLCore))]
+    [HarmonyPatch(typeof(XRL.XRLGame))]
     class Patch_XRL_Core_XRLCore
     {
         [HarmonyPostfix]

--- a/Screen Extenders/EnhancedScoreBoard.cs
+++ b/Screen Extenders/EnhancedScoreBoard.cs
@@ -63,7 +63,7 @@ namespace QudUX.ScreenExtenders
             int posGsf = details[line].IndexOf("Game summary for");
             if (posGsf > 0)
             {
-                Version = "0";
+                Version = 0;
             }
 
             try
@@ -183,10 +183,10 @@ namespace QudUX.ScreenExtenders
         public string CharacterName { get; set; }
         public DateTime DeathDate { get; set; }
         public string KilledBy { get; set; }
-        public int Level { get; set; }
+        //public int Level { get; set; }
         public int TurnsOld { get; set; }
-        public string Version { get; set; }
-        public bool Abandoned{get ; set;} 
+        //public string Version { get; set; }
+        public bool Abandoned{ get ; set; } 
 
         private void CopyFields(ScoreEntry2 scoreEntry)
         {


### PR DESCRIPTION
Stops EnhancedScoreBoard from hiding variables that already exist in the parent class. (Also fix type change for Version) Changes LoadGame Postfix to run on XRL.XRLGame.LoadGame(), since that is a function that exists